### PR TITLE
Fix publishing and building macos packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.14, macos-10.15]
+        os: [macos-10.15]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
       - run: brew install swig
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.14, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         arch: ['x64']
         include:
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.14, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         arch: ['x64']
         include:


### PR DESCRIPTION
Running `delocate` on the SecretHub macos wheel built
on macos 10.14, 10.15 or 11.0 will always result in a wheel
for macos 10.14, which is by default compatible with the other
two versions. This caused the publish job to fail as it tried
to publish the same wheel multiple times (from the different
matrix entries for the macos versions).

Therefore we can just build the macos wheel on any of the 3
macos versions. I decided to build it on 10.15 as it is not
deprecated and also not in preview.