### PR TITLE
Make `resolve_env` use python environment

### DIFF
--- a/secrethub/secrethub.i
+++ b/secrethub/secrethub.i
@@ -37,7 +37,9 @@ def export_env(self, env):
 Client.export_env = export_env
 
 def resolve_env(self):
+    res = {}
     for key, value in os.environ.items():
-        os.environ[key] = self.resolve(value)
+        res[key] = self.resolve(value)
+    return res
 Client.resolve_env = resolve_env
 %}

--- a/secrethub/secrethub.i
+++ b/secrethub/secrethub.i
@@ -3,12 +3,10 @@
 %{
 #include "datetime.h"
 PyObject *py_uuid = NULL;
-PyObject *py_json = NULL;
 %}
 
 %init %{
     py_uuid = PyImport_ImportModule("uuid");
-    py_json = PyImport_ImportModule("json");
     PyDateTime_IMPORT;
 %}
 
@@ -23,13 +21,6 @@ PyObject *py_json = NULL;
     PyObject *uuid_ctor = PyObject_GetAttrString(py_uuid, "UUID");
     PyObject *str = PyUnicode_DecodeUTF8($1, strlen($1), NULL);
     $result = PyObject_CallFunctionObjArgs(uuid_ctor, str, NULL);
-    Py_DECREF(str);
-}
-
-%typemap(out) char* ResolveEnv {
-    PyObject *json_loads = PyObject_GetAttrString(py_json, "loads");
-    PyObject *str = PyUnicode_DecodeUTF8($1, strlen($1), NULL);
-    $result = PyObject_CallFunctionObjArgs(json_loads, str, NULL);
     Py_DECREF(str);
 }
 

--- a/secrethub/secrethub.i
+++ b/secrethub/secrethub.i
@@ -44,4 +44,9 @@ def export_env(self, env):
     for key, value in env.items():
         os.environ[key] = value
 Client.export_env = export_env
+
+def resolve_env(self):
+    for key, value in os.environ.items():
+        os.environ[key] = self.resolve(value)
+Client.resolve_env = resolve_env
 %}

--- a/secrethub/secrethub.py
+++ b/secrethub/secrethub.py
@@ -139,8 +139,10 @@ def export_env(self, env):
 Client.export_env = export_env
 
 def resolve_env(self):
+    res = {}
     for key, value in os.environ.items():
-        os.environ[key] = self.resolve(value)
+        res[key] = self.resolve(value)
+    return res
 Client.resolve_env = resolve_env
 
 

--- a/secrethub/secrethub.py
+++ b/secrethub/secrethub.py
@@ -138,5 +138,10 @@ def export_env(self, env):
         os.environ[key] = value
 Client.export_env = export_env
 
+def resolve_env(self):
+    for key, value in os.environ.items():
+        os.environ[key] = self.resolve(value)
+Client.resolve_env = resolve_env
+
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -23,5 +23,11 @@ class TestSecretHubClient(unittest.TestCase):
         self.assertEqual(client.read_string(secret_name), secret_value)
         client.remove(secret_name)
 
+    def test_resolve_env(self):
+        os.environ['TEST'] = 'secrethub://'+TEST_DIR+'/test'
+        client = secrethub.Client()
+        client.export_env(client.resolve_env())
+        self.assertEqual(os.environ['TEST'], 'foo')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, any environment variables set from python were not visible to the python client, so resolve_env did not work in the following case:
```python3
os.environ['MY_SECRET'] = 'secrethub://path/to/secret'
client.export_env(client.resolve_env());
print("secret: " + os.environ['MY_SECRET']);
```

This PR fixes this issue by overriding `resolve_env` with a python function that uses python's `os.environ` (which also contains all the environment variables set in the python script) instead of using the Go function from the python sdk which does not see these variables.